### PR TITLE
Feature/save win score

### DIFF
--- a/lib/enemy.js
+++ b/lib/enemy.js
@@ -21,8 +21,9 @@ class Enemy {
   checkHealth() {
     if (this.health === 0) {
       this.cell.setValue(1);
-      this.grid.player.score += 100;
-      console.log(this.grid.player.score);
+      if (this.grid.player.health > 0) {
+        this.grid.player.score += 100;
+      }
     }
   }
 }

--- a/lib/game-engine.js
+++ b/lib/game-engine.js
@@ -11,6 +11,7 @@ class GameEngine {
     this.generator = new Generator(this.displayHandler, this.player);
     this.info = new Info(this);
     this.player.setEngine(this);
+    this.firstPass = 0;
   }
 
   play() {
@@ -42,7 +43,22 @@ class GameEngine {
   }
 
   gameWon() {
-    return this.level === 8;
+    if (this.firstPass === 0 && this.level === 8) {
+      this.firstPass++;
+    }
+    if (this.firstPass === 1 && this.level === 8) {
+      this.firstPass++;
+      this.level--;
+      this.info.saveScore();
+      this.info.displayScore();
+      this.level++;
+      return true;
+    }
+    if (this.level === 8) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   checkWinCondition(exit, player) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -15,17 +15,30 @@ class Info {
       score: this.game.player.score,
     };
     var sorted = this.sortLocalStorage();
-    if (entry.score > sorted[4].score || localStorage.length < 5) {
+    if (sorted.length < 5) {
+      localStorage.setItem(localStorage.length, JSON.stringify(entry));
+    } else if (entry.score > sorted[4].score) {
       localStorage.setItem(localStorage.length, JSON.stringify(entry));
     }
+
+
+    // if (entry.score > sorted[4].score || localStorage.length < 5) {
+    //   localStorage.setItem(localStorage.length, JSON.stringify(entry));
+    // }
   }
 
   displayScore() {
     if (localStorage.length > 0) {
       var sorted = this.sortLocalStorage();
       var formattedScores = "";
-      for(var i = 0; i < 5; i++) {
-        formattedScores += "<div>Floor: " + sorted[i].floor + " Score: " + sorted[i].score + "</div>";
+      if (sorted.length >= 5) {
+        for(var i = 0; i < 5; i++) {
+          formattedScores += "<div>Floor: " + sorted[i].floor + " Score: " + sorted[i].score + "</div>";
+        }
+      } else {
+        for(var j = 0; j < sorted.length; j++) {
+          formattedScores += "<div>Floor: " + sorted[j].floor + " Score: " + sorted[j].score + "</div>";
+        }
       }
       document.getElementById('high-score').removeAttribute('hidden');
       document.getElementById("score-board").innerHTML = formattedScores;

--- a/lib/info.js
+++ b/lib/info.js
@@ -20,11 +20,6 @@ class Info {
     } else if (entry.score > sorted[4].score) {
       localStorage.setItem(localStorage.length, JSON.stringify(entry));
     }
-
-
-    // if (entry.score > sorted[4].score || localStorage.length < 5) {
-    //   localStorage.setItem(localStorage.length, JSON.stringify(entry));
-    // }
   }
 
   displayScore() {


### PR DESCRIPTION
Fixed an issue where the score would not save on game win as well as the issue of localStorage breaking if there were less than 5 scores in localStorage. Also fixed the bug where the score displayed would be 100 higher than the score saved to the scoreboard and the floor would be one level higher. The scoreboard now functions fluidly and intuitively. 

-Added score save on victory
-Added catch inside of info for empty localStorage

-Changed score save to work with displayed score (you no longer gain points if you kill an enemy on death)
-Changed floor save to save the floor that you succeeded on
